### PR TITLE
Allow AffiliateMiddleware to ignore missing request.session.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,3 +213,6 @@ Optional
    ``Decimal("5.0")``
 -  ``AFFILIATE_REWARD_PERCENTAGE`` - reward is set in percent. Default
    ``True``
+-  ``AFFILIATE_ALLOW_MISSING_SESSION`` - allow ``request`` object to miss
+   "session" attribute. Processing of such requests will be skipped.
+   Default ``False``

--- a/affiliate/middleware.py
+++ b/affiliate/middleware.py
@@ -31,8 +31,8 @@ class AffiliateMiddleware(object):
         aid = None
         session = getattr(request, 'session')
         if not session:
-            l.error("session not set for request")
             if AFFILIATE_ALLOW_MISSING_SESSION:
+                l.warning("session not set for request")
                 return
             else:
                 raise ImproperlyConfigured("session attribute should be set for request. Please add 'django.contrib.sessions.middleware.SessionMiddleware' to your MIDDLEWARE_CLASSES")

--- a/affiliate/middleware.py
+++ b/affiliate/middleware.py
@@ -64,7 +64,11 @@ class AffiliateMiddleware(object):
     def process_response(self, request, response):
         aid = getattr(request, "aid", None)
         if not aid:
-            l.error("aid not set")
+            message = "aid not set"
+            if AFFILIATE_ALLOW_MISSING_SESSION:
+                l.warning(message)
+            else:
+                l.error(message)
         elif response.status_code == 200 and self.is_track_path(request.path):
             now = datetime.now()
             ip = get_client_ip(request)

--- a/affiliate/middleware.py
+++ b/affiliate/middleware.py
@@ -29,7 +29,7 @@ class AffiliateMiddleware(object):
 
     def process_request(self, request):
         aid = None
-        session = getattr(request, 'session')
+        session = getattr(request, 'session', None)
         if not session:
             if AFFILIATE_ALLOW_MISSING_SESSION:
                 l.warning("session not set for request")


### PR DESCRIPTION
Some setups may skip creation of session for specific urls (example: some anonymous api endpoints). In such cases using of AffiliateMiddleware middleware will cause requests to these urls to fail.

Proposed pull request introduces minimal changes for current behaviour when default settings are used: request will fail but with different exception (`ImproperlyConfigured` instead of `AttributeError`). But new setting `AFFILIATE_ALLOW_MISSING_SESSION` is added which may allow to skip requests with missing session
